### PR TITLE
feat: add dispatchOnParameters callback method

### DIFF
--- a/app/src/main/java/com/trinity/sample/RecordActivity.kt
+++ b/app/src/main/java/com/trinity/sample/RecordActivity.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.SharedPreferences
 import android.graphics.PointF
+import android.hardware.Camera
 import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
@@ -177,6 +178,9 @@ class RecordActivity : AppCompatActivity(), OnRecordingListener, OnRenderListene
   }
 
   override fun dispatchOnPreviewCallback(data: ByteArray, width: Int, height: Int, orientation: Int) {
+  }
+
+  override fun dispatchOnParameters(parameters: Camera.Parameters) {
   }
 
   private fun setFrame() {

--- a/library/src/main/java/com/trinity/camera/Camera1.kt
+++ b/library/src/main/java/com/trinity/camera/Camera1.kt
@@ -255,6 +255,7 @@ class Camera1(
       applyWhiteBalance(it)
       applyZoom(it, mZoom)
       applyExposureCorrection(it, mExposureCompensation)
+      mCameraCallback.dispatchOnParameters(it)
     }
     val size = computePreviewStreamSize(resolution)
     Log.i("trinity", "setPreviewSize width: ${size.width} height: ${size.height}")

--- a/library/src/main/java/com/trinity/camera/CameraCallback.kt
+++ b/library/src/main/java/com/trinity/camera/CameraCallback.kt
@@ -24,4 +24,5 @@ interface CameraCallback {
   fun dispatchOnFocusStart(where: PointF)
   fun dispatchOnFocusEnd(success: Boolean, where: PointF)
   fun dispatchOnPreviewCallback(data: ByteArray, width: Int, height: Int, orientation: Int)
+  fun dispatchOnParameters(parameters: android.hardware.Camera.Parameters)
 }

--- a/library/src/main/java/com/trinity/record/TrinityRecord.kt
+++ b/library/src/main/java/com/trinity/record/TrinityRecord.kt
@@ -21,6 +21,7 @@ package com.trinity.record
 import android.content.Context
 import android.graphics.PointF
 import android.graphics.SurfaceTexture
+import android.hardware.Camera
 import android.provider.Settings
 import android.provider.Settings.SettingNotFoundException
 import android.view.OrientationEventListener
@@ -397,6 +398,10 @@ class TrinityRecord(
     val result = mFaceDetection?.faceDetection(data, width, height, FaceDetectionImageType.YUV_NV21, inAngle, outAngle, flipType)
     mFaceDetectionReports = result
     onFrameAvailable(mHandle)
+  }
+
+  override fun dispatchOnParameters(parameters: Camera.Parameters) {
+    mCameraCallback?.dispatchOnParameters(parameters)
   }
 
   override fun update(timer: Timer, elapsedTime: Int) {


### PR DESCRIPTION
Expose camera parameters in a callback, so for example `supportedFlashModes` can be retrieved.