### PR TITLE
docs: fix simple typo, adaptative -> adaptive

### DIFF
--- a/extra/glm/readme.md
+++ b/extra/glm/readme.md
@@ -1178,7 +1178,7 @@ generation distribution
 
 ---
 ### GLM 0.2 - 2005-05-05
-- Improve adaptative from GLSL.
+- Improve adaptive from GLSL.
 - Add experimental extensions based on OpenGL extension process.
 - Fixe bugs.
 


### PR DESCRIPTION
There is a small typo in extra/glm/readme.md.

Should read `adaptive` rather than `adaptative`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md